### PR TITLE
Fix utf8.decoder with socket after update dart

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -67,7 +67,7 @@ class NatsClient {
       onConnect();
     }
     _protocolHandler = ProtocolHandler(socket: _socket, log: log);
-    _socket.transform(utf8.decoder).listen((data) {
+    utf8.decoder.bind(_socket).listen((data) {
       _serverPushString(data,
           connectionOptions: connectionOptions,
           onClusterupdate: onClusterupdate);


### PR DESCRIPTION
## What is this?
- [ ] New Feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] CI/CD

## Why this change?
-- Doesn't compile code --

After update dart version. Work with socket decoder has changed.